### PR TITLE
Correct some Action fields to be pointers

### DIFF
--- a/group.go
+++ b/group.go
@@ -16,15 +16,15 @@ import (
 // Action struct defines the state of a group
 type Action struct {
 	Alert     string    `json:"alert,omitempty"`
-	Bri       int       `json:"bri,omitempty"`
 	Colormode string    `json:"colormode,omitempty"`
-	Ct        int       `json:"ct,omitempty"`
 	Effect    string    `json:"effect,omitempty"`
-	Hue       int       `json:"hue,omitempty"`
-	On        bool      `json:"on,omitempty"`
-	Sat       int       `json:"sat,omitempty"`
-	XY        []float64 `json:"xy,omitempty"`
 	Scene     string    `json:"scene,omitempty"`
+	On        *bool     `json:"on,omitempty"`
+	Bri       *int      `json:"bri,omitempty"`
+	Ct        *int      `json:"ct,omitempty"`
+	Hue       *int      `json:"hue,omitempty"`
+	Sat       *int      `json:"sat,omitempty"`
+	XY        []float64 `json:"xy,omitempty"`
 }
 
 // Group struct defines the attributes for a group of lights.


### PR DESCRIPTION
Since we specify `omitempty` on all Action fields it's important that fields whose empty values are valid values to marshal, we must use pointer types, so that the empty value is nil, not the empty value of the type

For example, prior to this change you could not specify `On: false` and have it correctly be marshaled into a Action JSON.

This is a relatively big breaking change, since unfortunately any usages of `Action`s will now need to be updated to pass reference values, which unfortunately can be relatively ugly :( 