### PR TITLE
Removed redundant light.On calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ func main() {
 
     lights, _ := bridge.GetAllLights()
     for _, light := range lights {
-        light.On()
         light.SetBrightness(100)
         light.ColorLoop(true)
     }


### PR DESCRIPTION
Light.On is called before Light.SetBrightness(100) which is not necessary because the Light.SetBrightness Spec already sets the value of Light.On to true in the LightState struct.