### PR TITLE
Add initial support for Groups

### DIFF
--- a/group.go
+++ b/group.go
@@ -2,6 +2,7 @@
 * group.go
 * GoHue library for Philips Hue
 * Copyright (C) 2016 Collin Guarino (Collinux) collin.guarino@gmail.com
+* Copyright (C) 2018 Niels de Vos (nixpanic) niels@nixpanic.net
 * License: GPL version 2 or higher http://www.gnu.org/licenses/gpl.html
  */
 // http://www.developers.meethue.com/documentation/groups-api
@@ -10,7 +11,9 @@ package hue
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 )
 
 // Action struct defines the state of a group
@@ -27,33 +30,102 @@ type Action struct {
 	Scene     string    `json:"scene,omitempty"`
 }
 
-// Group struct defines the attributes for a group of lights.
-type Group struct {
-	Action Action   `json:"action"`
-	Lights []string `json:"lights"`
-	Name   string   `json:"name"`
-	Type   string   `json:"type"`
+// State of a group, allows for detecting if (some) lighs are on.
+type State struct {
+	AllOn bool `json:"all_on"`
+	AnyOn bool `json:"any_on"`
 }
 
-// GetGroups gets the attributes for each group of lights.
-// TODO: NOT TESTED, NOT FULLY IMPLEMENTED
-func (bridge *Bridge) GetGroups() ([]Group, error) {
+// Group struct defines the attributes for a group of lights.
+type Group struct {
+	Action    Action  ` json:"action"`
+	// LightsInt is the string (Index) representation of a `Light`. Use the
+	// `Lights` array to access details of the `Light`s
+	LightsInt []string `json:"lights"`
+	Name      string   `json:"name"`
+	Type      string   `json:"type"`
+	// Class of the group, `Room` or `LightGroup` (unknown if others exist).
+	Class     string   `json:"class"`
+	Recycle   bool     `json:"recycle"`
+
+	// Status of the lights in the group.
+	State     State    `json:"state"`
+
+	// Index of this Groups in the list as returned by the Hue bridge.
+	Index     int
+
+	// The bridge itsef
+	Bridge    *Bridge
+	// The Light instances in this Group
+	Lights    []Light
+}
+
+// GetAllGroups gets the attributes for each group of lights.
+func (bridge *Bridge) GetAllGroups() ([]Group, error) {
 	uri := fmt.Sprintf("/api/%s/groups", bridge.Username)
 	body, _, err := bridge.Get(uri)
 	if err != nil {
-		return []Group{}, err
+		return nil, err
 	}
 
-	//fmt.Println("GROUP GET: ", string(body))
-
-	groups := map[string]Group{}
-	err = json.Unmarshal(body, &groups)
+	groupMap := map[string]Group{}
+	err = json.Unmarshal(body, &groupMap)
 	if err != nil {
-		return []Group{}, err
+		return nil, err
 	}
-	//fmt.Println("GROUPS: ", groups)
 
-	return []Group{}, nil
+	// Ideally Group.Lights should be filled with actual light objects
+	lights, err := bridge.GetAllLights()
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failed to get lights for groups: %s", err))
+	}
+
+	// Parse the index, add the light to the list, and return the array
+	groups := []Group{}
+	for index, group := range groupMap {
+		group.Index, err = strconv.Atoi(index)
+		if err != nil {
+			return []Group{}, errors.New("Unable to convert group index to integer. ")
+		}
+
+		group.Bridge = bridge
+
+		// this is not optimal, but we'll assume there won't be hundreds of lights
+		for _, lightStr := range(group.LightsInt) {
+			lightInt, err := strconv.Atoi(lightStr)
+			if err != nil {
+				return nil, errors.New(fmt.Sprintf("failed to convert group.light.index (%s) to int", lightStr))
+			}
+
+			for _, light := range(lights) {
+				if light.Index == lightInt {
+					group.Lights = append(group.Lights, light)
+					break
+				}
+			}
+		}
+
+		groups = append(groups, group)
+	}
+
+	return groups, nil
+}
+
+// GetGroupByName() uses GetAllGroups() to fetch all the groups, and returns
+// the group with the given name if it exists.
+func (bridge *Bridge) GetGroupByName(name string) (*Group, error) {
+	groups, err := bridge.GetAllGroups()
+	if err != nil {
+		return nil, errors.New("failed to get groups")
+	}
+
+	for _, group := range(groups) {
+		if group.Name == name {
+			return &group, nil
+		}
+	}
+
+	return nil, errors.New(fmt.Sprintf("group \"%s\" not found", name))
 }
 
 // SetGroupState sends an action to group
@@ -64,4 +136,73 @@ func (bridge *Bridge) SetGroupState(group int, action *Action) error {
 		return err
 	}
 	return nil
+}
+
+// The request to send to the Hue bridge to create a new group.
+type newGroupRequest struct {
+	Lights []string `json:"lights,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	Type   string   `json:"type,omitempty"`
+	Class  string   `json:"class,omitempty"`
+}
+
+// Create a new group with `name`. The `type` of the group will be `Room` with
+// `class` defaulting to `Other`.
+func (bridge *Bridge) NewGroup(name string, class string, lights []Light) (*Group, error) {
+	uri := fmt.Sprintf("/api/%s/groups", bridge.Username)
+
+	lightsStr := []string{}
+	for _, light := range(lights) {
+		lightsStr = append(lightsStr, fmt.Sprintf("%d", light.Index))
+	}
+
+	req := newGroupRequest{
+		Name: name,
+		Type: "Room", // TODO: by default the new group is a room (LightGroup exists too)
+		Lights: lightsStr,
+	}
+
+	if class != "" {
+		req.Class = class
+	}
+
+	_, _, err := bridge.Post(uri, req)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("group %s has been created with %d lights\n", name, len(lights))
+
+	// TODO: return the new group
+	return nil, nil
+}
+
+// Delete the group from the Hue bridge.
+func (group *Group) Delete() error {
+	uri := fmt.Sprintf("/api/%s/groups/%d", group.Bridge.Username, group.Index)
+	err := group.Bridge.Delete(uri)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Turn the lights in the group on.
+func (group *Group) On() error {
+	on := true
+	onAction := Action{
+		On: &on,
+	}
+
+	return group.Bridge.SetGroupState(group.Index, &onAction)
+}
+
+// Turn the lights in the group off.
+func (group *Group) Off() error {
+	on := false
+	offAction := Action{
+		On: &on,
+	}
+
+	return group.Bridge.SetGroupState(group.Index, &offAction)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -12,14 +12,14 @@ import (
 	"testing"
 )
 
-func TestGetGroups(t *testing.T) {
+func TestGetAllGroups(t *testing.T) {
 	bridges, err := hue.FindBridges()
 	if err != nil {
 		t.Fatal(err)
 	}
 	bridge := bridges[0]
 	bridge.Login("427de8bd6d49f149c8398e4fc08f")
-	groups, err := bridge.GetGroups()
+	groups, err := bridge.GetAllGroups()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds support for the following functions that act on a Group:

- Bridge.GetAllGroups()
  Returns an array of all the groups that are known to the bridge
  (this function has been renamed from Bridge.GetGroups() to match the
   Bridge.GetAllLights(), GetAllScenes() naming scheme)

- Bridge.GetGroupByName(name)
  Returns the group with the given name, or an error if not found

- Bridge.NewGroup(name, class, lights[])
  Create a new group

- Group.Delete()
  Remove the group from the bridge

- Group.On()
  Turn all the lights in the group on

- Group.Off()
  Turn all the lights in the group off