### PR TITLE
Locate the bridge using discovery.meethue.com

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -153,8 +153,8 @@ func HandleResponse(resp *http.Response) ([]byte, io.Reader, error) {
 // FindBridges will visit www.meethue.com/api/nupnp to see a list of
 // bridges on the local network.
 func FindBridges() ([]Bridge, error) {
-	bridge := Bridge{IPAddress: "www.meethue.com"}
-	body, _, err := bridge.Get("/api/nupnp")
+	bridge := Bridge{IPAddress: "discovery.meethue.com"}
+	body, _, err := bridge.Get("/")
 	if err != nil {
 		err = errors.New("unable to locate bridge")
 		return []Bridge{}, err


### PR DESCRIPTION
The endpoint http://www.meethue.com/api/nupnp  is shutdown (at least I get a 404 error) and the new endpoint is: https://discovery.meethue.com/

This means the `findBridge` call is no longer working at the moment.

I tested it locally,  the new URL is a replacement which just works after changing the url path and doing a GET to `/`

Source: https://developers.meethue.com/news/ 